### PR TITLE
fix timezone bug

### DIFF
--- a/arduinoESP8266/arduinoESP8266.ino
+++ b/arduinoESP8266/arduinoESP8266.ino
@@ -55,8 +55,8 @@ void loop() {
   time_t local = CE.toLocal(utc);
 
   // Hole die aktuelle Stunde, Minute und Sekunde von der NTP-Zeit
-  int stunden = timeClient.getHours();
-  int minuten = timeClient.getMinutes();
+  int stunden = hour(local);
+  int minuten = minute(local);
 
 
   // Setze die LEDs basierend auf der aktuellen Zeit


### PR DESCRIPTION
Hi!

We ran into a bug similar to what was described in #3 by @ctobio

This update uses the hour and minute from the `local` time variable instead of `timeClient` directly.

It also looks like the `timeClient` is instantiated with an offset of `3600` seconds (+1 hour), so `timeClient.getHour()` was returning an adjusted time, which probably made it difficult to see that the `local` time variable was not being used at all!

Hope this helps others. Thanks for putting this project together!